### PR TITLE
Show resource names instead of IDs

### DIFF
--- a/source/backend/discovery/src/discovery/generateHeader.js
+++ b/source/backend/discovery/src/discovery/generateHeader.js
@@ -3,12 +3,11 @@
  * Generates the text that should be displayed on the graph next to each resource
  * 
  */
+const R = require('ramda');
 
 // sets the title to the resourceName if exists, falls back to resourceId - default
-const buildGeneric = (data) => {
-    data.properties.title = ('resourceName' in data.properties)
-        ? data.properties.resourceName
-        : data.properties.resourceId;
+const buildGeneric = ({properties}) => {
+    properties.title = R.defaultTo(properties.resourceId, properties.resourceName);
 }
 
 // Sets the title to the resourceName

--- a/source/backend/discovery/src/discovery/generateHeader.js
+++ b/source/backend/discovery/src/discovery/generateHeader.js
@@ -4,9 +4,11 @@
  * 
  */
 
-// sets the title to the resourceId - default
+// sets the title to the resourceName if exists, falls back to resourceId - default
 const buildGeneric = (data) => {
-    data.properties.title = data.properties.resourceId;
+    data.properties.title = ('resourceName' in data.properties)
+        ? data.properties.resourceName
+        : data.properties.resourceId;
 }
 
 // Sets the title to the resourceName


### PR DESCRIPTION
*Issue #:* #29 (partially)

*Description of changes:*
Use resource name if available, fall back to ID.

Note: there's no tests, I'm not entirely sure if it works as expected, please check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
