### PR TITLE
Enable buildspec.yaml customization

### DIFF
--- a/source/backend/discovery/buildspec.yml
+++ b/source/backend/discovery/buildspec.yml
@@ -1,22 +1,17 @@
 version: 0.2
-
 phases:
-  install:
-    runtime-versions:
-      docker: 18
   pre_build:
     commands:
-      - cd source/backend/perspective-discovery/
-      - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+      - echo ${IMAGE_VERSION}
+      - $(aws ecr get-login --no-include-email)
+      - IMAGE_URI="${REPOSITORY_URI}"
   build:
     commands:
       - echo Build started on `date`
-      - echo Building the Docker image...          
-      - docker build -t $IMAGE_REPO_NAME:$CODEBUILD_RESOLVED_SOURCE_VERSION .
-      - docker tag $IMAGE_REPO_NAME:$CODEBUILD_RESOLVED_SOURCE_VERSION $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$IMAGE_REPO_NAME:$CODEBUILD_RESOLVED_SOURCE_VERSION     
+      - echo Building the Docker image...
+      - docker build --tag $IMAGE_URI:${IMAGE_VERSION} .
   post_build:
     commands:
       - echo Build completed on `date`
       - echo Pushing the Docker image...
-      - docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$IMAGE_REPO_NAME:$CODEBUILD_RESOLVED_SOURCE_VERSION
+      - docker push $IMAGE_URI:${IMAGE_VERSION}

--- a/source/cfn/templates/zoom-discovery-crawler.yaml
+++ b/source/cfn/templates/zoom-discovery-crawler.yaml
@@ -401,27 +401,9 @@ Resources:
             reason: 'Happy with the default behaviour of using AWS-managed CMK'
     Properties:
       Artifacts:
-        Type: NO_ARTIFACTS
+        Type: CODEPIPELINE
       Source:
-        Type: NO_SOURCE
-        BuildSpec: |
-          version: 0.2
-          phases:
-            pre_build:
-              commands:
-                - echo ${IMAGE_VERSION}
-                - $(aws ecr get-login --no-include-email)
-                - IMAGE_URI="${REPOSITORY_URI}"                
-            build:
-              commands:
-                - echo Build started on `date`
-                - echo Building the Docker image...
-                - docker build --tag $IMAGE_URI:${IMAGE_VERSION} .
-            post_build:
-              commands:
-                - echo Build completed on `date`
-                - echo Pushing the Docker image...
-                - docker push $IMAGE_URI:${IMAGE_VERSION}
+        Type: CODEPIPELINE
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: aws/codebuild/docker:18.09.0

--- a/source/cfn/templates/zoom-discovery-crawler.yaml
+++ b/source/cfn/templates/zoom-discovery-crawler.yaml
@@ -339,8 +339,7 @@ Resources:
                             "ecr:PutImage",
                             "ecr:InitiateLayerUpload",
                             "ecr:UploadLayerPart",
-                            "ecr:CompleteLayerUpload",
-                            "ecr:GetAuthorizationToken"
+                            "ecr:CompleteLayerUpload"
                         ]
                     },
                     {
@@ -349,7 +348,10 @@ Resources:
                             "*"
                         ],
                         "Action": [
-                            "ecr:GetAuthorizationToken"
+                            "ecr:GetAuthorizationToken",
+                            "ecr:GetDownloadUrlForLayer",
+                            "ecr:BatchGetImage",
+                            "ecr:BatchCheckLayerAvailability"
                         ]
                     }
                 ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The discovery component runs in a docker base image that triggers ECR security warnings.
We're trying to build it on top of our pre-baked docker node12 base image that is updated regularly. I was trying to re-use the existing build pipeline and update `buildspec.yaml` and `Dockerfile`. I stumbled on 2 issues:
- build spec is hardcoded in CloudFormation templates. There's `source/backend/discovery/buildspec.yml` but it's not in use (maybe internally?)
- CodeBuild doesn't have permissions to pull from another ECR

With this PR the build pipeline for the discovery component should become more flexible and allow some customisation.

Summary of the changes:
 - Move hardcoded `buildspec.yaml` from CloudFormation template to `source/backend/discovery/buildspec.yml` in order to allow customisation
 - Add actions required to pull docker base images from any ECR
 - Remove duplicated `ecr:GetAuthorizationToken` action

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
